### PR TITLE
Saving the Runtime Test environment to the claims.json

### DIFF
--- a/pkg/config/autodiscover/autodiscover_targets.go
+++ b/pkg/config/autodiscover/autodiscover_targets.go
@@ -217,8 +217,9 @@ func buildPodUnderTest(pr *PodResource) (podUnderTest *configsections.Pod) {
 }
 
 // buildOperatorFromCSVResource builds a single `configsections.Operator` from a CSVResource
-func buildOperatorFromCSVResource(csv *CSVResource, istest bool) (op configsections.Operator) {
+func buildOperatorFromCSVResource(csv *CSVResource, istest bool) (op *configsections.Operator) {
 	var err error
+	op = &configsections.Operator{}
 	op.Name = csv.Metadata.Name
 	op.Namespace = csv.Metadata.Namespace
 
@@ -265,14 +266,14 @@ func getConfiguredOperatorTests() []string {
 // setBundleAndIndexImage provides the bundle image and index image for a given CSV.
 // These variables are saved in the `configsections.Operator` in order to be used by DCI,
 // which obtains them from the claim.json and provides them to preflight suite.
-func setBundleAndIndexImage(csvName string, csvNamespace string) (string, string) {
+func setBundleAndIndexImage(csvName, csvNamespace string) (bundleImage, indexImage string) {
 	// First step is to extract the installplan related to the csv
 	installPlanCmd := fmt.Sprintf("oc get installplan -n %s | grep %q | awk '{ print $1 }'", csvNamespace, csvName)
 	installPlan := execCommandOutput(installPlanCmd)
 
 	// Then, retrieve the bundle image using the installplan
 	bundleImageCmd := fmt.Sprintf("oc get installplan -n %s %s -o json | jq .status.bundleLookups[].path", csvNamespace, installPlan)
-	bundleImage := execCommandOutput(bundleImageCmd)
+	bundleImage = execCommandOutput(bundleImageCmd)
 
 	// To retrieve the index image, we firstly need the catalogsource and the namespace in which it is deployed
 	catalogSourceNameCmd := fmt.Sprintf("oc get installplan -n %s %s -o json | jq .status.bundleLookups[].catalogSourceRef.name", csvNamespace, installPlan)
@@ -282,7 +283,7 @@ func setBundleAndIndexImage(csvName string, csvNamespace string) (string, string
 
 	// Then, we can retrieve the index image
 	indexImageCmd := fmt.Sprintf("oc get catalogsource -n %s %s -o json | jq .spec.image", catalogSourceNamespace, catalogSourceName)
-	indexImage := execCommandOutput(indexImageCmd)
+	indexImage = execCommandOutput(indexImageCmd)
 
 	return bundleImage, indexImage
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,7 +107,7 @@ type TestEnvironment struct {
 	PodsUnderTest        []*configsections.Pod
 	DeploymentsUnderTest []configsections.PodSet
 	StateFulSetUnderTest []configsections.PodSet
-	OperatorsUnderTest   []configsections.Operator
+	OperatorsUnderTest   []*configsections.Operator
 	NameSpacesUnderTest  []string
 	CrdNames             []string
 	NodesUnderTest       map[string]*NodeConfig

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -102,7 +102,7 @@ type TestTarget struct {
 	// ExcludeContainersFromConnectivityTests excludes specific containers from network connectivity tests.  This is particularly useful for containers that don't have ping available.
 	ExcludeContainersFromConnectivityTests []ContainerIdentifier `yaml:"excludeContainersFromConnectivityTests" json:"excludeContainersFromConnectivityTests"`
 	// Operator is the list of operator objects that needs to be tested.
-	Operators []Operator `yaml:"operators,omitempty"  json:"operators,omitempty"`
+	Operators []*Operator `yaml:"operators,omitempty"  json:"operators,omitempty"`
 	//
 	// Node list
 	Nodes map[string]Node `yaml:"Nodes"  json:"Nodes"`

--- a/pkg/config/configsections/config_section_test.go
+++ b/pkg/config/configsections/config_section_test.go
@@ -125,7 +125,7 @@ func loadOperatorConfig() {
 	operator.Name = operatorName
 	operator.Namespace = operatorNameSpace
 	operator.Tests = []string{testcases.OperatorStatus}
-	test.Operators = append(test.Operators, operator)
+	test.Operators = append(test.Operators, &operator)
 	loadPodConfig()
 }
 

--- a/pkg/config/configsections/container.go
+++ b/pkg/config/configsections/container.go
@@ -125,7 +125,7 @@ type ContainerIdentifier struct {
 	ContainerRuntime string `yaml:"containerRuntime" json:"containerRuntime"`
 }
 
-func (cid *ContainerIdentifier) MarshalText() (text []byte, err error) {
+func (cid ContainerIdentifier) MarshalText() (text []byte, err error) { //nolint:gocritic // This is the type for a key using pointer won't work
 	return []byte(cid.Namespace + "_" +
 		cid.PodName + "_" +
 		cid.ContainerName + "_" +

--- a/pkg/config/configsections/container.go
+++ b/pkg/config/configsections/container.go
@@ -40,14 +40,14 @@ var (
 // as the reference to the interactive.Oc instance, the reference to the test configuration, and the default network
 // IP address.
 type Container struct {
-	ContainerIdentifier
-	Oc          *interactive.Oc
-	ImageSource *ContainerImageSource
+	ContainerIdentifier `yaml:"ContainerIdentifier" json:"ContainerIdentifier"`
+	Oc                  *interactive.Oc       `yaml:"-" json:"-"`
+	ImageSource         *ContainerImageSource `yaml:"ImageSource" json:"ImageSource"`
 }
 
 type ContainerImageSource struct {
-	Registry string
-	ContainerImageIdentifier
+	Registry                 string `yaml:"Registry" json:"Registry"`
+	ContainerImageIdentifier `yaml:"ContainerImageIdentifier" json:"ContainerImageIdentifier"`
 }
 
 // Tag and Digest should not be populated at the same time. Digest takes precedence if both are populated
@@ -123,6 +123,15 @@ type ContainerIdentifier struct {
 	NodeName         string `yaml:"nodeName" json:"nodeName"`
 	ContainerUID     string `yaml:"containerUID" json:"containerUID"`
 	ContainerRuntime string `yaml:"containerRuntime" json:"containerRuntime"`
+}
+
+func (cid *ContainerIdentifier) MarshalText() (text []byte, err error) {
+	return []byte(cid.Namespace + "_" +
+		cid.PodName + "_" +
+		cid.ContainerName + "_" +
+		cid.NodeName + "_" +
+		cid.ContainerUID + "_" +
+		cid.ContainerRuntime), nil
 }
 
 func (cid *ContainerIdentifier) String() string {

--- a/test-network-function/diagnostic/diagnostic.go
+++ b/test-network-function/diagnostic/diagnostic.go
@@ -37,6 +37,8 @@ var (
 
 	nodesHwInfo = NodesHwInfo{}
 
+	initialRuntimeTestEnvironment config.TestEnvironment
+
 	// csiDriver stores the csi driver JSON output of `oc get csidriver -o json`
 	csiDriver = make(map[string]interface{})
 
@@ -118,6 +120,8 @@ func GetDiagnosticData() []error {
 		errs = append(errs, hwErrs...)
 	}
 
+	saveInitialRuntimeEnv()
+
 	return errs
 }
 
@@ -179,6 +183,11 @@ func GetNodesHwInfo() NodesHwInfo {
 // GetCsiDriverInfo returns the CSI driver info of running `oc get csidriver -o json`.
 func GetCsiDriverInfo() map[string]interface{} {
 	return csiDriver
+}
+
+// GetInitialRuntimeEnv returns initial test environment
+func GetInitialRuntimeEnv() config.TestEnvironment {
+	return initialRuntimeTestEnvironment
 }
 
 func getMasterNodeName(env *config.TestEnvironment) string {
@@ -313,6 +322,12 @@ func getNodesHwInfo() []error {
 	errs = append(errs, getNodeHwInfo(&nodesHwInfo.Worker, workerNodeName, "worker")...)
 
 	return errs
+}
+
+// saveInitialRuntimeEnv Saves the initial runtime environment to a global variable for use in suite_test.go
+func saveInitialRuntimeEnv() {
+	log.Infof("Saving initial runtime environement in diagnostics")
+	initialRuntimeTestEnvironment = *config.GetTestEnvironment()
 }
 
 func getNodeLscpu(nodeName string) (map[string]string, error) {

--- a/test-network-function/operator/suite.go
+++ b/test-network-function/operator/suite.go
@@ -100,10 +100,10 @@ func testOperatorsAreInstalledViaOLM(env *config.TestEnvironment) {
 
 			test.RunWithCallbacks(nil, func() {
 				tnf.ClaimFilePrintf("Operator %s doesn't have a proper OLM subscription.", operatorInTest.Name)
-				badOperators = append(badOperators, operatorInTest)
+				badOperators = append(badOperators, *operatorInTest)
 			}, func(err error) {
 				tnf.ClaimFilePrintf("Operator %s doesn't have a proper OLM subscription. Error: %v", operatorInTest.Name, err)
-				badOperators = append(badOperators, operatorInTest)
+				badOperators = append(badOperators, *operatorInTest)
 			})
 		}
 
@@ -155,10 +155,10 @@ func runTestsOnOperator(env *config.TestEnvironment, testCase testcases.BaseTest
 
 			test.RunWithCallbacks(nil, func() {
 				tnf.ClaimFilePrintf("Operator %s failed TC: %s", name, testCase.Name)
-				badOperators = append(badOperators, op)
+				badOperators = append(badOperators, *op)
 			}, func(err error) {
 				tnf.ClaimFilePrintf("Operator %s failed TC: %s. Error: %v", name, testCase.Name, err)
-				badOperators = append(badOperators, op)
+				badOperators = append(badOperators, *op)
 			})
 		}
 

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -268,15 +268,17 @@ func writeClaimOutput(claimOutputFile string, payload []byte) {
 
 func generateNodes() map[string]interface{} {
 	const (
-		nodeSummaryField = "nodeSummary"
-		cniPluginsField  = "cniPlugins"
-		nodesHwInfo      = "nodesHwInfo"
-		csiDriverInfo    = "csiDriver"
+		nodeSummaryField  = "nodeSummary"
+		cniPluginsField   = "cniPlugins"
+		nodesHwInfo       = "nodesHwInfo"
+		csiDriverInfo     = "csiDriver"
+		initialRuntimeEnv = "InitialRuntimeEnv"
 	)
 	nodes := map[string]interface{}{}
 	nodes[nodeSummaryField] = diagnostic.GetNodeSummary()
 	nodes[cniPluginsField] = diagnostic.GetCniPlugins()
 	nodes[nodesHwInfo] = diagnostic.GetNodesHwInfo()
 	nodes[csiDriverInfo] = diagnostic.GetCsiDriverInfo()
+	nodes[initialRuntimeEnv] = diagnostic.GetInitialRuntimeEnv()
 	return nodes
 }


### PR DESCRIPTION
This PR complements the work done by Ramon to get the operator bundle image and index by saving both pieces of info to the claims file. The whole initial runtime environment is also saved .