### PR TITLE
Remove initial runtime environment storage.

### DIFF
--- a/test-network-function/diagnostic/diagnostic.go
+++ b/test-network-function/diagnostic/diagnostic.go
@@ -37,8 +37,6 @@ var (
 
 	nodesHwInfo = NodesHwInfo{}
 
-	initialRuntimeTestEnvironment config.TestEnvironment
-
 	// csiDriver stores the csi driver JSON output of `oc get csidriver -o json`
 	csiDriver = make(map[string]interface{})
 
@@ -120,8 +118,6 @@ func GetDiagnosticData() []error {
 		errs = append(errs, hwErrs...)
 	}
 
-	saveInitialRuntimeEnv()
-
 	return errs
 }
 
@@ -183,11 +179,6 @@ func GetNodesHwInfo() NodesHwInfo {
 // GetCsiDriverInfo returns the CSI driver info of running `oc get csidriver -o json`.
 func GetCsiDriverInfo() map[string]interface{} {
 	return csiDriver
-}
-
-// GetInitialRuntimeEnv returns initial test environment
-func GetInitialRuntimeEnv() config.TestEnvironment {
-	return initialRuntimeTestEnvironment
 }
 
 func getMasterNodeName(env *config.TestEnvironment) string {
@@ -322,12 +313,6 @@ func getNodesHwInfo() []error {
 	errs = append(errs, getNodeHwInfo(&nodesHwInfo.Worker, workerNodeName, "worker")...)
 
 	return errs
-}
-
-// saveInitialRuntimeEnv Saves the initial runtime environment to a global variable for use in suite_test.go
-func saveInitialRuntimeEnv() {
-	log.Infof("Saving initial runtime environement in diagnostics")
-	initialRuntimeTestEnvironment = *config.GetTestEnvironment()
 }
 
 func getNodeLscpu(nodeName string) (map[string]string, error) {

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -279,6 +279,5 @@ func generateNodes() map[string]interface{} {
 	nodes[cniPluginsField] = diagnostic.GetCniPlugins()
 	nodes[nodesHwInfo] = diagnostic.GetNodesHwInfo()
 	nodes[csiDriverInfo] = diagnostic.GetCsiDriverInfo()
-	nodes[initialRuntimeEnv] = diagnostic.GetInitialRuntimeEnv()
 	return nodes
 }


### PR DESCRIPTION
The discovered operators are already dumped in the testTarget section of
the claim file (claim.configurations.testTarget.operators), so adding
the new fields in the operator struct is enough for this PR.